### PR TITLE
feat(Spotify): Bump librespot to 1.6.6-SNAPSHOT + set playback to local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ node_modules/
 
 # One package is called the same as the Gradle build folder
 !**/src/**/build/
+
+local.properties

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,8 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">
-    <file type="web" url="file://$PROJECT_DIR$/../revanced-api" />
     <file type="web" url="file://$PROJECT_DIR$" />
+    <file type="web" url="file://$PROJECT_DIR$/../revanced-api" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" default="true" project-jdk-name="azul-17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="azul-17" project-jdk-type="JavaSDK" />
 </project>

--- a/extensions/spotify/build.gradle.kts
+++ b/extensions/spotify/build.gradle.kts
@@ -5,11 +5,30 @@ plugins {
     alias(libs.plugins.protobuf)
     id("com.github.johnrengelman.shadow") version "8.1.1"
 }
-
+repositories {
+    gradlePluginPortal()
+    google()
+    maven {
+        name = "GitHubPackages"
+        url = uri("https://maven.pkg.github.com/revanced/registry")
+        credentials {
+            username = providers.gradleProperty("gpr.user").getOrElse(System.getenv("GITHUB_ACTOR"))
+            password = providers.gradleProperty("gpr.key").getOrElse(System.getenv("GITHUB_TOKEN"))
+        }
+    }
+    maven {
+        name = "GitHubPackages2"
+        url = uri("https://maven.pkg.github.com/Emiferpro/librespot-java")
+        credentials {
+            username = providers.gradleProperty("gpr.user").getOrElse(System.getenv("GITHUB_ACTOR"))
+            password = providers.gradleProperty("gpr.key").getOrElse(System.getenv("GITHUB_TOKEN"))
+        }
+    }
+}
 val internalize by configurations.creating
 
 dependencies {
-    internalize("xyz.gianlu.librespot:librespot-player:1.6.5:thin") {
+    internalize("xyz.gianlu.librespot:librespot-player:1.6.6-SNAPSHOT:thin") {
         exclude(group = "xyz.gianlu.librespot", module = "librespot-sink")
         exclude(group = "com.lmax", module = "disruptor")
         exclude(group = "org.apache.logging.log4j")

--- a/extensions/spotify/src/main/java/app/revanced/extension/spotify/misc/fix/AndroidZeroconfServer.java
+++ b/extensions/spotify/src/main/java/app/revanced/extension/spotify/misc/fix/AndroidZeroconfServer.java
@@ -14,8 +14,8 @@ import org.jetbrains.annotations.Nullable;
 import xyz.gianlu.librespot.common.NameThreadFactory;
 import xyz.gianlu.librespot.common.Utils;
 import xyz.gianlu.librespot.core.Session;
+import xyz.gianlu.librespot.core.TokenProvider;
 import xyz.gianlu.librespot.crypto.DiffieHellman;
-import xyz.gianlu.librespot.mercury.MercuryClient;
 
 import javax.crypto.Cipher;
 import javax.crypto.Mac;
@@ -391,7 +391,7 @@ public class AndroidZeroconfServer implements Closeable {
             for (SessionListener l : sessionListeners) {
                 l.sessionChanged(session);
             }
-        } catch (Session.SpotifyAuthenticationException | MercuryClient.MercuryException | IOException |
+        } catch (Session.SpotifyAuthenticationException | TokenProvider.TokenException | IOException |
                  GeneralSecurityException ex) {
             LOGGER.error("Couldn't establish a new session.", ex);
 

--- a/patches/api/patches.api
+++ b/patches/api/patches.api
@@ -984,6 +984,10 @@ public final class app/revanced/patches/spotify/misc/privacy/SanitizeSharingLink
 	public static final fun getSanitizeSharingLinksPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 }
 
+public final class app/revanced/patches/spotify/misc/volume/ForceLocalPlaybackPatchKt {
+	public static final fun getForceLocalPlaybackPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
+}
+
 public final class app/revanced/patches/spotify/misc/widgets/FixThirdPartyLaunchersWidgetsKt {
 	public static final fun getFixThirdPartyLaunchersWidgets ()Lapp/revanced/patcher/patch/BytecodePatch;
 }

--- a/patches/src/main/kotlin/app/revanced/patches/spotify/misc/volume/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/spotify/misc/volume/Fingerprints.kt
@@ -1,0 +1,21 @@
+package app.revanced.patches.spotify.misc.volume
+
+import app.revanced.patcher.fingerprint
+import app.revanced.util.getReference
+import app.revanced.util.indexOfFirstInstruction
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.iface.reference.*;
+
+internal val forceLocalPlaybackFingerprint = fingerprint {
+    accessFlags(AccessFlags.PUBLIC, AccessFlags.FINAL)
+    returns("V")
+    parameters("Lp/vgc;")
+
+    strings("mediaSessionCompat")
+
+    custom { method, _ ->
+        method.indexOfFirstInstruction {
+            getReference<MethodReference>()?.name == "setPlaybackToRemote"
+        } >= 0
+    }
+}

--- a/patches/src/main/kotlin/app/revanced/patches/spotify/misc/volume/ForceLocalPlaybackPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/spotify/misc/volume/ForceLocalPlaybackPatch.kt
@@ -1,0 +1,56 @@
+package app.revanced.patches.spotify.misc.volume
+
+import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
+import app.revanced.patcher.extensions.InstructionExtensions.getInstruction
+import app.revanced.patcher.extensions.InstructionExtensions.instructions
+import app.revanced.patcher.extensions.InstructionExtensions.removeInstructions
+import app.revanced.patcher.patch.bytecodePatch
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.iface.reference.Reference
+
+
+val forceLocalPlaybackPatch = bytecodePatch(
+    name = "Force Local Playback",
+    description = "Forces playback to be local by using AudioAttributes instead of remote playback.",
+) {
+    compatibleWith("com.spotify.music")
+
+    execute {
+        val method = forceLocalPlaybackFingerprint.method
+        val instructions = method.instructions
+
+        val remoteCallIndex = instructions.indexOfFirst {
+            it.opcode == Opcode.INVOKE_VIRTUAL &&
+                    it.getReferenceOrNull<MethodReference>()?.name == "setPlaybackToRemote"
+        }
+
+        if (remoteCallIndex == -1) error("setPlaybackToRemote call not found")
+
+        val remoteCall = method.getInstruction<FiveRegisterInstruction>(remoteCallIndex)
+        val sessionRegister = remoteCall.registerC
+
+        method.removeInstructions(remoteCallIndex, 1)
+
+        val smaliCode = """
+            new-instance v1, Landroid/media/AudioAttributes#Builder;
+            invoke-direct {v1}, Landroid/media/AudioAttributes#Builder;-><init>()V
+            const/4 v2, 0x3
+            invoke-virtual {v1, v2}, Landroid/media/AudioAttributes#Builder;->setLegacyStreamType(I)Landroid/media/AudioAttributes#Builder;
+            move-result-object v1
+            invoke-virtual {v1}, Landroid/media/AudioAttributes#Builder;->build()Landroid/media/AudioAttributes;
+            move-result-object v1
+            invoke-virtual {p${sessionRegister}, v1}, Landroid/media/session/MediaSession;->setPlaybackToLocal(Landroid/media/AudioAttributes;)V
+        """.trimIndent().replace('#', '$')
+
+        method.addInstructions(
+            remoteCallIndex, smaliCode
+        )
+    }
+}
+
+inline fun <reified T : Reference> Any.getReferenceOrNull(): T? {
+    return (this as? ReferenceInstruction)?.reference as? T
+}


### PR DESCRIPTION
This patch fixes the crash when selecting revanced as output. Also it makes android think we are playing to the phone speakers and not to a remote device, allowing us to change the volume normally